### PR TITLE
Move skeleton tokens from foundations to component

### DIFF
--- a/src/SkeletonIcon/styles.js
+++ b/src/SkeletonIcon/styles.js
@@ -1,5 +1,5 @@
 import styled, { css, keyframes } from "styled-components";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "../Tokens/tokens";
 
 const shimmer = keyframes`
 0% {
@@ -16,7 +16,7 @@ const StyledSkeletonIcon = styled.div`
   width: ${({ $size }) => $size};
   height: ${({ $size }) => $size};
   background: ${({ theme }) =>
-    theme?.skeleton?.background?.color || inube.skeleton.background.color};
+    theme?.skeleton?.background?.color || tokens.background.color};
 
   ${({ $animated }) =>
     $animated &&
@@ -28,15 +28,9 @@ const StyledSkeletonIcon = styled.div`
         width: 100%;
         background: ${({ theme }) => `linear-gradient(
       100deg,
-      ${
-        theme?.skeleton?.background?.color || inube.skeleton.background.color
-      } 0%,
-      ${
-        theme?.skeleton?.animation?.color || inube.skeleton.animation.color
-      } 50%,
-      ${
-        theme?.skeleton?.background?.color || inube.skeleton.background.color
-      } 100%
+      ${theme?.skeleton?.background?.color || tokens.background.color} 0%,
+      ${theme?.skeleton?.animation?.color || tokens.animation.color} 50%,
+      ${theme?.skeleton?.background?.color || tokens.background.color} 100%
     );`};
         animation: ${shimmer} 2s linear infinite;
       }

--- a/src/SkeletonLine/styles.js
+++ b/src/SkeletonLine/styles.js
@@ -1,5 +1,5 @@
 import styled, { keyframes, css } from "styled-components";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "../Tokens/tokens";
 
 const shimmer = keyframes`
 0% {
@@ -10,16 +10,14 @@ const shimmer = keyframes`
   }
 `;
 
-export const StyledSkeletonLine = styled.div`
+const StyledSkeletonLine = styled.div`
   position: relative;
   border-radius: 6px;
   overflow: hidden;
   height: 16px;
   width: ${({ $width }) => $width};
   background: ${({ theme }) => {
-    return (
-      theme?.skeleton?.background?.color || inube.skeleton.background.color
-    );
+    return theme?.skeleton?.background?.color || tokens.background.color;
   }};
 
   ${({ $animated }) =>
@@ -32,17 +30,13 @@ export const StyledSkeletonLine = styled.div`
         width: 100%;
         background: ${({ theme }) => `linear-gradient(
       100deg,
-      ${
-        theme?.skeleton?.background?.color || inube.skeleton.background.color
-      } 0%,
-      ${
-        theme?.skeleton?.animation?.color || inube.skeleton.animation.color
-      } 50%,
-      ${
-        theme?.skeleton?.background?.color || inube.skeleton.background.color
-      } 100%
+      ${theme?.skeleton?.background?.color || tokens.background.color} 0%,
+      ${theme?.skeleton?.animation?.color || tokens.animation.color} 50%,
+      ${theme?.skeleton?.background?.color || tokens.background.color} 100%
     );`};
         animation: ${shimmer} 2s linear infinite;
       }
     `}
 `;
+
+export { StyledSkeletonLine };

--- a/src/Tokens/tokens.ts
+++ b/src/Tokens/tokens.ts
@@ -1,0 +1,12 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  background: {
+    color: inube.palette.neutral.N30,
+  },
+  animation: {
+    color: inube.palette.neutral.N10,
+  },
+};
+
+export { tokens };


### PR DESCRIPTION
This PR relocates the skeleton tokens from the foundations folder to the component folder, updating all necessary imports to reflect the new structure and ensuring components reference the correct token paths. This change enhances the organization, maintainability, and clarity of the codebase.